### PR TITLE
Bump version to 0.0.6

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,8 +10,8 @@ SetPackageInfo( rec(
 
 PackageName := "GRPS1024",
 Subtitle := "Library of the groups of order 1024.",
-Version := "0.0.5",
-Date := "20/06/2022", # dd/mm/yyyy format
+Version := "0.0.6",
+Date := "31/07/2026", # dd/mm/yyyy format
 License := "Artistic-2.0",
 
 Persons := [


### PR DESCRIPTION
PackageInfo.g had been stuck at 0.0.5 (2022) despite the chunked storage rewrite, checksum tooling, and Zenodo data migration all landing since then. 0.0.6 was already showing on the live gh-pages site (bumped there directly at some point, out of band); this backfills main as the source of truth so the site's displayed version/date no longer regresses when gh-pages is regenerated.