### PR TITLE
Remove stale header comment from makedoc.g

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -1,6 +1,3 @@
-#
-# LinearCentralizers: Centralizers in Special and General Linear Groups over Finite Fields
-#
 # This file is a script which compiles the package manual.
 #
 if fail = LoadPackage("AutoDoc", "2018.02.14") then


### PR DESCRIPTION
## Summary
- Removes a leftover header comment in `makedoc.g` that duplicated the package description and no longer matched the file's purpose.

## Test plan
- N/A (comment-only change)